### PR TITLE
feat: add "POST /tools"

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,6 +71,24 @@ MOCK_VERSION = {
         "verified_source",
     ]
 }
+MOCK_VERSION_POST = {
+    "author": [
+        "author"
+    ],
+    'descriptor_type': None,
+    "images": None,
+    "included_apps": [
+        "https://bio.tools/tool/mytum.de/SNAP2/1",
+        "https://bio.tools/bioexcel_seqqc"
+    ],
+    "is_production": True,
+    "name": "name",
+    "signed": True,
+    "verified": None,
+    "verified_source": [
+        "verified_source",
+    ]
+}
 MOCK_TOOL_CLASS_WITH_ID = {
     "description": "description",
     "id": "234561",
@@ -93,6 +111,22 @@ MOCK_TOOL = {
     "url": "abc.com",
     "versions": [
         MOCK_VERSION
+    ]
+}
+MOCK_TOOL_POST = {
+    "aliases": [
+        "alias_1",
+        "alias_2",
+        "alias_3",
+    ],
+    "checker_url": "checker_url",
+    "description": "description",
+    "has_checker": True,
+    "name": "name",
+    "organization": "organization",
+    "toolclass": MOCK_TOOL_CLASS_WITH_ID,
+    "versions": [
+        MOCK_VERSION_POST
     ]
 }
 MOCK_TOOL_CLASS = {
@@ -162,6 +196,33 @@ class TestPostToolClass:
         """Raises InvalidPayload when incorrect input is provided"""
         with pytest.raises(InvalidPayload):
             self.cli.post_tool_class(
+                payload=MOCK_RESPONSE_INVALID
+            )
+
+
+class TestPostTool:
+    """Test poster for tools."""
+
+    cli = TRSClient(
+        uri=MOCK_TRS_URI,
+        token=MOCK_TOKEN,
+    )
+    endpoint = (
+        f"{cli.uri}/tools"
+    )
+
+    def test_success(self, monkeypatch, requests_mock):
+        """Returns 200 response."""
+        requests_mock.post(self.endpoint, json=MOCK_ID)
+        r = self.cli.post_tool(
+            payload=MOCK_TOOL_POST
+        )
+        assert r == MOCK_ID
+
+    def test_success_InvalidPayload(self, requests_mock):
+        """Raises InvalidPayload when incorrect input is provided"""
+        with pytest.raises(InvalidPayload):
+            self.cli.post_tool(
                 payload=MOCK_RESPONSE_INVALID
             )
 

--- a/trs_cli/client.py
+++ b/trs_cli/client.py
@@ -31,6 +31,7 @@ from trs_cli.models import (
     Tool,
     ToolClass,
     ToolClassRegister,
+    ToolRegister,
 )
 
 logger = logging.getLogger(__name__)
@@ -159,6 +160,67 @@ class TRSClient():
         )
         logger.info(
             "Registered tool class"
+        )
+        return response  # type: ignore
+
+    def post_tool(
+        self,
+        payload: Dict,
+        accept: str = 'application/json',
+        token: Optional[str] = None,
+    ) -> str:
+        """Register a tool.
+
+        Arguments:
+            payload: Tool data.
+            accept: Requested content type.
+            token: Bearer token for authentication. Set if required by TRS
+                implementation and if not provided when instatiating client or
+                if expired.
+
+        Returns:
+            ID of registered TRS tool in case of a `200` response, or an
+            instance of `Error` for all other responses.
+        Raises:
+            requests.exceptions.ConnectionError: A connection to the provided
+                TRS instance could not be established.
+            trs_cli.errors.InvalidPayload: The object data payload could not
+                be validated against the API schema.
+            trs_cli.errors.InvalidResponseError: The response could not be
+                validated against the API schema.
+        """
+        # validate requested content type and get request headers
+        self._validate_content_type(
+            requested_type=accept,
+            available_types=['application/json'],
+        )
+        self._get_headers(
+            content_accept=accept,
+            content_type='application/json',
+            token=token,
+        )
+
+        # build request URL
+        url = f"{self.uri}/tools"
+        logger.info(f"Connecting to '{url}'...")
+
+        # validate payload
+        try:
+            ToolRegister(**payload).dict()
+        except pydantic.ValidationError:
+            raise InvalidPayload(
+                "The tool data could not be validated against API "
+                "schema."
+            )
+
+        # send request
+        response = self._send_request_and_validate_response(
+            url=url,
+            method='post',
+            payload=payload,
+        )
+        logger.info(
+            "Registered tool"
         )
         return response  # type: ignore
 


### PR DESCRIPTION
* add access method for endpoint `POST /tools`
* replace `trs_cli.errors.InvalidPayload` errors with the more informative `pydantic.ValidationError`s when validating request payloads

Closes #21 